### PR TITLE
Validate time-token interval and document error handling

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -185,6 +185,16 @@ std::string token = hmac::generate_time_token(secret_key, fingerprint, 60);
 bool is_valid = hmac::is_token_valid(token, secret_key, fingerprint, 60);
 ```
 
+Если `interval_sec` неположителен, функции выбросят `std::invalid_argument`:
+
+```cpp
+try {
+    hmac::generate_time_token(secret_key, 0);
+} catch (const std::invalid_argument& e) {
+    std::cout << e.what();
+}
+```
+
 Подходит для авторизации, защиты API и одноразовых токенов.
 
 ## 📄 Пример

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ std::string token = hmac::generate_time_token(secret_key, fingerprint, 60);
 bool is_valid = hmac::is_token_valid(token, secret_key, fingerprint, 60);
 ```
 
+If `interval_sec` is not positive, the functions throw `std::invalid_argument`:
+
+```cpp
+try {
+    hmac::generate_time_token(secret_key, 0);
+} catch (const std::invalid_argument& e) {
+    std::cout << e.what();
+}
+```
+
 This is useful for stateless authentication, API protection, and one-time tokens.
 
 ## 📄 Example

--- a/example.cpp
+++ b/example.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <string>
+#include <stdexcept>
 #include "hmac.hpp"
 #include "hmac_utils.hpp"
 
@@ -66,6 +67,19 @@ int main() {
     std::cout << "Token = " << timed_token << std::endl;
     bool valid_fp = hmac::is_token_valid(timed_token, key, fingerprint, 60);
     std::cout << "Token valid (with fingerprint)? = " << (valid_fp ? "YES" : "NO") << std::endl;
+
+    // HMAC TIME TOKEN with invalid interval
+    print_section("HMAC-TIMED TOKEN (invalid interval)");
+    try {
+        hmac::generate_time_token(key, 0);
+    } catch (const std::invalid_argument& e) {
+        std::cout << "generate_time_token error: " << e.what() << std::endl;
+    }
+    try {
+        hmac::is_token_valid(time_token, key, 0);
+    } catch (const std::invalid_argument& e) {
+        std::cout << "is_token_valid error: " << e.what() << std::endl;
+    }
 
     // TOTP
     std::string totp_key = "12345678901234567890"; // raw binary string (not base32!)

--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -6,12 +6,18 @@
 namespace hmac {
 
     std::string generate_time_token(const std::string &key, int interval_sec, TypeHash hash_type) {
+        if (interval_sec <= 0) {
+            throw std::invalid_argument("interval_sec must be positive");
+        }
         auto now = std::time(nullptr);
         std::time_t rounded = (now / interval_sec) * interval_sec;
         return get_hmac(key, std::to_string(rounded), hash_type);
     }
 
     bool is_token_valid(const std::string &token, const std::string &key, int interval_sec, TypeHash hash_type) {
+        if (interval_sec <= 0) {
+            throw std::invalid_argument("interval_sec must be positive");
+        }
         auto now = std::time(nullptr);
         std::time_t rounded = (now / interval_sec) * interval_sec;
         if (token == get_hmac(key, std::to_string(rounded), hash_type)) return true;
@@ -21,6 +27,9 @@ namespace hmac {
     }
 
     std::string generate_time_token(const std::string &key, const std::string &fingerprint, int interval_sec, TypeHash hash_type) {
+        if (interval_sec <= 0) {
+            throw std::invalid_argument("interval_sec must be positive");
+        }
         auto now = std::time(nullptr);
         std::time_t rounded = (now / interval_sec) * interval_sec;
         std::string payload = std::to_string(rounded) + "|" + fingerprint;
@@ -28,6 +37,9 @@ namespace hmac {
     }
 
     bool is_token_valid(const std::string &token, const std::string &key, const std::string &fingerprint, int interval_sec, TypeHash hash_type) {
+        if (interval_sec <= 0) {
+            throw std::invalid_argument("interval_sec must be positive");
+        }
         auto now = std::time(nullptr);
         std::time_t rounded = (now / interval_sec) * interval_sec;
         std::string prefix = "|" + fingerprint;

--- a/hmac_utils.hpp
+++ b/hmac_utils.hpp
@@ -9,7 +9,7 @@ namespace hmac {
 
     /// \brief Generates a time-based HMAC-SHA256 token
     /// \param key Secret key used for HMAC
-    /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
+    /// \param interval_sec Interval in seconds that defines token rotation. Must be positive. Default is 60 seconds
     /// \param hash_type Hash function to use (SHA1, SHA256, SHA512). Default is SHA256
     /// \return Hex-encoded HMAC-SHA256 of the rounded time value
     std::string generate_time_token(const std::string &key, int interval_sec = 60, TypeHash hash_type = TypeHash::SHA256);
@@ -17,7 +17,7 @@ namespace hmac {
     /// \brief Validates a time-based HMAC-SHA256 token with ±1 interval tolerance
     /// \param token Token received from the client
     /// \param key Secret key used for HMAC
-    /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
+    /// \param interval_sec Interval in seconds that defines token rotation. Must be positive. Default is 60 seconds
     /// \param hash_type Hash function to use (SHA1, SHA256, SHA512). Default is SHA256
     /// \return true if the token is valid within the ±1 interval range; false otherwise
     bool is_token_valid(const std::string &token, const std::string &key, int interval_sec = 60, TypeHash hash_type = TypeHash::SHA256);
@@ -25,7 +25,7 @@ namespace hmac {
     /// \brief Generates a time-based HMAC-SHA256 token with fingerprint binding
     /// \param key Secret key used for HMAC
     /// \param fingerprint Unique client identifier (e.g., device ID or session hash)
-    /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
+    /// \param interval_sec Interval in seconds that defines token rotation. Must be positive. Default is 60 seconds
     /// \param hash_type Hash function to use (SHA1, SHA256, SHA512). Default is SHA256
     /// \return Hex-encoded HMAC-SHA256 of the concatenated timestamp and fingerprint
     std::string generate_time_token(const std::string &key, const std::string &fingerprint, int interval_sec = 60, TypeHash hash_type = TypeHash::SHA256);
@@ -34,7 +34,7 @@ namespace hmac {
     /// \param token Token received from the client
     /// \param key Secret key used for HMAC
     /// \param fingerprint Unique client identifier (e.g., device ID or session hash)
-    /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
+    /// \param interval_sec Interval in seconds that defines token rotation. Must be positive. Default is 60 seconds
     /// \param hash_type Hash function to use (SHA1, SHA256, SHA512). Default is SHA256
     /// \return true if the token is valid within the ±1 interval range; false otherwise
     bool is_token_valid(const std::string &token, const std::string &key, const std::string &fingerprint, int interval_sec = 60, TypeHash hash_type = TypeHash::SHA256);


### PR DESCRIPTION
## Summary
- validate `interval_sec` in time token helpers and throw `std::invalid_argument` on non-positive values
- document that `interval_sec` must be positive and show failure examples

## Testing
- `cmake -B build -DBUILD_EXAMPLE=ON`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfceedc8832ca58c2620723df018