### PR TITLE
Fix TOTP validation for early timestamps

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -103,7 +103,9 @@ namespace hmac {
         int64_t counter = static_cast<int64_t>(timestamp / period);
         if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter), digits, hash_type)) return true;
         if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter + 1), digits, hash_type)) return true;
-        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter - 1), digits, hash_type)) return true;
+        if (counter > 0 &&
+            token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter - 1), digits, hash_type))
+            return true;
         return false;
     }
 
@@ -115,7 +117,13 @@ namespace hmac {
             int digits,
             TypeHash hash_type) {
         uint64_t timestamp = static_cast<uint64_t>(std::time(nullptr));
-        return is_totp_token_valid(token, key_ptr, key_len, timestamp, period, digits, hash_type);
+        int64_t counter = static_cast<int64_t>(timestamp / period);
+        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter), digits, hash_type)) return true;
+        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter + 1), digits, hash_type)) return true;
+        if (counter > 0 &&
+            token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter - 1), digits, hash_type))
+            return true;
+        return false;
     }
 
 } // namespace hmac

--- a/test_totp.cpp
+++ b/test_totp.cpp
@@ -1,0 +1,25 @@
+#include "hmac_utils.hpp"
+#include <cassert>
+#include <limits>
+#include <iostream>
+
+int main() {
+    std::string key = "12345678901234567890";
+    int digits = 6;
+    uint64_t period = 30;
+    uint64_t early_timestamp = 5; // less than one period
+
+    // Token generated for counter = 0 should be valid at early timestamp
+    int token_counter0 = hmac::get_hotp_code(key.data(), key.size(), 0, digits, hmac::TypeHash::SHA1);
+    bool valid = hmac::is_totp_token_valid(token_counter0, key.data(), key.size(), early_timestamp, period, digits, hmac::TypeHash::SHA1);
+    assert(valid);
+
+    // Token from max counter should NOT be considered valid when timestamp is in the first period
+    uint64_t max_counter = std::numeric_limits<uint64_t>::max();
+    int token_max = hmac::get_hotp_code(key.data(), key.size(), max_counter, digits, hmac::TypeHash::SHA1);
+    bool valid_max = hmac::is_totp_token_valid(token_max, key.data(), key.size(), early_timestamp, period, digits, hmac::TypeHash::SHA1);
+    assert(!valid_max);
+
+    std::cout << "TOTP early timestamp test passed" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- guard TOTP validation against counter underflow by checking `counter > 0`
- ensure system-time overload mirrors counter check
- add test covering early timestamp validation

## Testing
- `g++ -std=c++11 test_totp.cpp hmac_utils.cpp hmac.cpp sha1.cpp sha256.cpp sha512.cpp -I. -o test_totp && ./test_totp`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfcd4f50832ca84cc0bc5c9e76df