### PR TITLE
Use consistent timestamp in TOTP helper

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -85,9 +85,9 @@ namespace hmac {
     int get_totp_code(
             const void* key_ptr,
             size_t key_len,
-        int period,
-        int digits,
-        TypeHash hash_type) {
+            int period,
+            int digits,
+            TypeHash hash_type) {
         uint64_t timestamp = static_cast<uint64_t>(std::time(nullptr));
         return get_totp_code_at(key_ptr, key_len, timestamp, period, digits, hash_type);
     }

--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -85,11 +85,11 @@ namespace hmac {
     int get_totp_code(
             const void* key_ptr,
             size_t key_len,
-            int period, 
-            int digits, 
-            TypeHash hash_type) {
+        int period,
+        int digits,
+        TypeHash hash_type) {
         uint64_t timestamp = static_cast<uint64_t>(std::time(nullptr));
-        return get_totp_code_at(key_ptr, key_len, std::time(nullptr), period, digits, hash_type);
+        return get_totp_code_at(key_ptr, key_len, timestamp, period, digits, hash_type);
     }
 
     bool is_totp_token_valid(


### PR DESCRIPTION
## Summary
- ensure `get_totp_code` reuses the calculated timestamp when delegating to `get_totp_code_at`

## Testing
- `cmake -B build -DBUILD_EXAMPLE=ON`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfc5cc68832cacdbc4de50bdcb57