### PR TITLE
Fix SHA1 comment in TypeHash enum

### DIFF
--- a/hmac.hpp
+++ b/hmac.hpp
@@ -10,7 +10,7 @@ namespace hmac {
 
     /// \brief Type of the hash function used
     enum class TypeHash {
-        SHA1,   ///< Use SHA256
+        SHA1,   ///< Use SHA1
         SHA256, ///< Use SHA256
         SHA512, ///< Use SHA512
     };


### PR DESCRIPTION
## Summary
- Correct `TypeHash::SHA1` comment to reference SHA1

## Testing
- `g++ -std=c++17 example.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -o example`
- `./example <<'EOF'

EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b7cfc10278832ca927d02617b5790c