### PR TITLE
Restrict OTP digit range to 1-9

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -41,7 +41,7 @@ namespace hmac {
     }
 
     int get_hotp_code(const void* key_ptr, size_t key_len, uint64_t counter, int digits, TypeHash hash_type) {
-        if (digits < 1 || digits > 10) throw std::invalid_argument("HOTP: digits must be in range [1, 9]");
+        if (digits < 1 || digits > 9) throw std::invalid_argument("HOTP: digits must be in range [1, 9]");
 
         // Step 1: Pack counter as 8-byte big-endian
         uint8_t counter_bytes[8];
@@ -77,7 +77,7 @@ namespace hmac {
             int period, 
             int digits, 
             TypeHash hash_type) {
-        if (period <= 0 || digits <= 0 || digits > 10) return 0;
+        if (period <= 0 || digits <= 0 || digits > 9) return 0;
         uint64_t counter = timestamp / period;
         return get_hotp_code(key_ptr, key_len, counter, digits, hash_type);
     }


### PR DESCRIPTION
## Summary
- limit HOTP/TOTP digit range to 1-9
- clarify HOTP exception for digit bounds

## Testing
- `g++ -std=c++11 example.cpp hmac_utils.cpp hmac.cpp sha1.cpp sha256.cpp sha512.cpp -o example`
- `/tmp/test_digits`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf969a10832cbfe153de49fa74d0