### PR TITLE
Use uint64_t counter in TOTP validation

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -111,11 +111,11 @@ namespace hmac {
             int period,
             int digits,
             TypeHash hash_type) {
-        int64_t counter = static_cast<int64_t>(timestamp / period);
-        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter), digits, hash_type)) return true;
-        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter + 1), digits, hash_type)) return true;
+        uint64_t counter = timestamp / period;
+        if (token == get_hotp_code(key_ptr, key_len, counter, digits, hash_type)) return true;
+        if (token == get_hotp_code(key_ptr, key_len, counter + 1, digits, hash_type)) return true;
         if (counter > 0 &&
-            token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter - 1), digits, hash_type))
+            token == get_hotp_code(key_ptr, key_len, counter - 1, digits, hash_type))
             return true;
         return false;
     }
@@ -128,11 +128,11 @@ namespace hmac {
             int digits,
             TypeHash hash_type) {
         uint64_t timestamp = static_cast<uint64_t>(std::time(nullptr));
-        int64_t counter = static_cast<int64_t>(timestamp / period);
-        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter), digits, hash_type)) return true;
-        if (token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter + 1), digits, hash_type)) return true;
+        uint64_t counter = timestamp / period;
+        if (token == get_hotp_code(key_ptr, key_len, counter, digits, hash_type)) return true;
+        if (token == get_hotp_code(key_ptr, key_len, counter + 1, digits, hash_type)) return true;
         if (counter > 0 &&
-            token == get_hotp_code(key_ptr, key_len, static_cast<uint64_t>(counter - 1), digits, hash_type))
+            token == get_hotp_code(key_ptr, key_len, counter - 1, digits, hash_type))
             return true;
         return false;
     }


### PR DESCRIPTION
## Summary
- Ensure TOTP validation uses unsigned 64-bit counters
- Avoid signed overflow by checking counter before decrement

## Testing
- `g++ -std=c++17 test_totp.cpp hmac_utils.cpp hmac.cpp sha1.cpp sha256.cpp sha512.cpp -o test_totp && ./test_totp`


------
https://chatgpt.com/codex/tasks/task_e_68b7e71f2cb4832c8210dbd3cdcb61ce