### PR TITLE
Use const uint8_t* for hash input

### DIFF
--- a/hmac.cpp
+++ b/hmac.cpp
@@ -23,7 +23,7 @@ namespace hmac {
                 std::fill(digest, digest + hmac_hash::SHA1::DIGEST_SIZE, '\0');
                 hmac_hash::SHA1 ctx = hmac_hash::SHA1();
                 ctx.init();
-                ctx.update((uint8_t*)input.c_str(), input.size());
+                ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.size());
                 ctx.finish(digest);
                 return std::string((const char*)digest, hmac_hash::SHA1::DIGEST_SIZE);
             }
@@ -32,7 +32,7 @@ namespace hmac {
                 std::fill(digest, digest + hmac_hash::SHA256::DIGEST_SIZE, '\0');
                 hmac_hash::SHA256 ctx = hmac_hash::SHA256();
                 ctx.init();
-                ctx.update((uint8_t*)input.c_str(), input.size());
+                ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.size());
                 ctx.finish(digest);
                 return std::string((const char*)digest, hmac_hash::SHA256::DIGEST_SIZE);
             }
@@ -41,7 +41,7 @@ namespace hmac {
                 std::fill(digest, digest + hmac_hash::SHA512::DIGEST_SIZE, '\0');
                 hmac_hash::SHA512 ctx = hmac_hash::SHA512();
                 ctx.init();
-                ctx.update((uint8_t*)input.c_str(), input.size());
+                ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.size());
                 ctx.finish(digest);
                 return std::string((const char*)digest, hmac_hash::SHA512::DIGEST_SIZE);
             }

--- a/sha1.cpp
+++ b/sha1.cpp
@@ -47,7 +47,7 @@ namespace hmac_hash {
         m_buffer.clear();
     }
     
-    void SHA1::update(const unsigned char *message, size_t length) {
+    void SHA1::update(const uint8_t *message, size_t length) {
         size_t offset = 0;
 
         // Fill buffer if it has existing bytes
@@ -240,7 +240,7 @@ namespace hmac_hash {
 
         hmac_hash::SHA1 ctx;
         ctx.init();
-        ctx.update((uint8_t*)input.c_str(), input.length());
+        ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.length());
         ctx.finish(digest);
 
         char buf[2 * hmac_hash::SHA1::DIGEST_SIZE + 1];

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -136,7 +136,7 @@ namespace hmac_hash {
         m_tot_len = 0;
     }
 
-    void SHA256::update(const unsigned char *message, size_t length) {
+    void SHA256::update(const uint8_t *message, size_t length) {
         size_t block_nb;
         size_t new_len, rem_len, tmp_len;
         const uint8_t *shifted_message;
@@ -198,7 +198,7 @@ namespace hmac_hash {
 
         hmac_hash::SHA256 ctx;
         ctx.init();
-        ctx.update((uint8_t*)input.c_str(), input.length());
+        ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.length());
         ctx.finish(digest);
 
         char buf[2 * hmac_hash::SHA256::DIGEST_SIZE + 1];

--- a/sha512.cpp
+++ b/sha512.cpp
@@ -234,7 +234,7 @@ namespace hmac_hash {
         std::fill(digest, digest + hmac_hash::SHA512::DIGEST_SIZE, '\0');
         hmac_hash::SHA512 ctx;
         ctx.init();
-        ctx.update((uint8_t*)input.c_str(), input.length());
+        ctx.update(reinterpret_cast<const uint8_t*>(input.data()), input.length());
         ctx.finish(digest);
 
         char buf[2 * hmac_hash::SHA512::DIGEST_SIZE + 1];


### PR DESCRIPTION
## Summary
- use `reinterpret_cast<const uint8_t*>` when hashing string data
- make SHA1 and SHA256 `update` definitions take `const uint8_t*`

## Testing
- `g++ -std=c++11 example.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -o example`
- `./example`


------
https://chatgpt.com/codex/tasks/task_e_68b7e6eec460832cbf250ea8fe055371