### PR TITLE
docs: add CI badges

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -1,5 +1,8 @@
 # hmac-cpp
 
+[![Linux](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Linux.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Linux.yml)
+[![Windows](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Win.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Win.yml)
+
 Лёгкая `C++11` библиотека для вычисления `HMAC` (hash-based message authentication code), поддерживающая поддерживающая `SHA256`, `SHA512`, `SHA1`, а также одноразовые пароли `HOTP` и `TOTP`.
 
 ## 🚀 Возможности

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # hmac-cpp [🇷🇺 README-RU](./README-RU.md)
 
+[![Linux](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Linux.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Linux.yml)
+[![Windows](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Win.yml/badge.svg?branch=main)](https://github.com/NewYaroslav/hmac-cpp/actions/workflows/CI-Win.yml)
+
 A lightweight `C++11` library for computing `HMAC` (hash-based message authentication codes), supporting `SHA1`, `SHA256`, `SHA512`, as well as one-time passwords compliant with `HOTP` (RFC 4226) and `TOTP` (RFC 6238).
 
 ## 🚀 Features


### PR DESCRIPTION
## Summary
- add GitHub Actions badges for Linux and Windows to README files

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8a66c30bc832ca2fa3b394084c559