### PR TITLE
Handle 64-bit message lengths in SHA256

### DIFF
--- a/sha256.cpp
+++ b/sha256.cpp
@@ -155,21 +155,22 @@ namespace hmac_hash {
         rem_len = new_len % SHA224_256_BLOCK_SIZE;
         memcpy(m_block, &shifted_message[block_nb << 6], rem_len);
         m_len = rem_len;
-        m_tot_len += (block_nb + 1) << 6;
+        m_tot_len += static_cast<uint64_t>(block_nb + 1) << 6;
     }
 
     void SHA256::finish(uint8_t *digest) {
         size_t block_nb;
         size_t pm_len;
-        size_t len_b;
+        uint64_t len_b;
         size_t i;
-        block_nb = (1 + ((SHA224_256_BLOCK_SIZE - 9) 
+        block_nb = (1 + ((SHA224_256_BLOCK_SIZE - 9)
             < (m_len % SHA224_256_BLOCK_SIZE)));
         len_b = (m_tot_len + m_len) << 3;
         pm_len = block_nb << 6;
         memset(m_block + m_len, 0, pm_len - m_len);
         m_block[m_len] = 0x80;
-        SHA2_UNPACK32(len_b, m_block + pm_len - 4);
+        SHA2_UNPACK32(static_cast<uint32_t>(len_b >> 32), m_block + pm_len - 8);
+        SHA2_UNPACK32(static_cast<uint32_t>(len_b & 0xFFFFFFFF), m_block + pm_len - 4);
         transform(m_block, block_nb);
         for(i = 0 ; i < 8; ++i) {
             SHA2_UNPACK32(m_h[i], &digest[i << 2]);

--- a/sha256.hpp
+++ b/sha256.hpp
@@ -72,7 +72,7 @@ namespace hmac_hash {
 
     protected:
         void transform(const uint8_t *message, size_t block_nb);
-        size_t m_tot_len;
+        uint64_t m_tot_len;
         size_t m_len;
         uint8_t m_block[2 * SHA224_256_BLOCK_SIZE];
         uint32_t m_h[8];

--- a/sha256.mqh
+++ b/sha256.mqh
@@ -42,7 +42,7 @@ namespace hmac_hash {
 
     protected:
         void transform(const uchar &message[], int block_nb);
-        int m_tot_len;
+        ulong m_tot_len;
         int m_len;
         uchar m_block[2 * SHA224_256_BLOCK_SIZE];
         uint m_h[8];
@@ -141,19 +141,23 @@ namespace hmac_hash {
         rem_len = new_len % SHA224_256_BLOCK_SIZE;
         ArrayCopy(m_block, shifted_message, 0, block_nb * SHA224_256_BLOCK_SIZE, rem_len);
         m_len = rem_len;
-        m_tot_len += (block_nb + 1) * SHA224_256_BLOCK_SIZE;
+        m_tot_len += (ulong)(block_nb + 1) * SHA224_256_BLOCK_SIZE;
     }
 
     void SHA256::finish(uchar &digest[]) {
         int block_nb;
         int pm_len;
-        int len_b;
+        ulong len_b;
         int i;
         block_nb = (1 + ((SHA224_256_BLOCK_SIZE - 9) < (m_len % SHA224_256_BLOCK_SIZE)));
         len_b = (m_tot_len + m_len) << 3;
         pm_len = block_nb * SHA224_256_BLOCK_SIZE;
         for (int k = m_len; k < pm_len; ++k) m_block[k] = 0;
         m_block[m_len] = 0x80;
+        m_block[pm_len - 8] = (uchar)((len_b >> 56) & 0xFF);
+        m_block[pm_len - 7] = (uchar)((len_b >> 48) & 0xFF);
+        m_block[pm_len - 6] = (uchar)((len_b >> 40) & 0xFF);
+        m_block[pm_len - 5] = (uchar)((len_b >> 32) & 0xFF);
         m_block[pm_len - 4] = (uchar)((len_b >> 24) & 0xFF);
         m_block[pm_len - 3] = (uchar)((len_b >> 16) & 0xFF);
         m_block[pm_len - 2] = (uchar)((len_b >> 8) & 0xFF);

--- a/sha512.mqh
+++ b/sha512.mqh
@@ -45,7 +45,7 @@ namespace hmac_hash {
 
     protected:
         void transform(const uchar &message[], int block_nb);
-        int m_tot_len;
+        ulong m_tot_len;
         int m_len;
         uchar m_block[2 * SHA384_512_BLOCK_SIZE];
         ulong m_h[8];
@@ -169,19 +169,23 @@ namespace hmac_hash {
         rem_len = new_len % SHA384_512_BLOCK_SIZE;
         ArrayCopy(m_block, shifted_message, 0, block_nb * SHA384_512_BLOCK_SIZE, rem_len);
         m_len = rem_len;
-        m_tot_len += (block_nb + 1) * SHA384_512_BLOCK_SIZE;
+        m_tot_len += (ulong)(block_nb + 1) * SHA384_512_BLOCK_SIZE;
     }
 
     void SHA512::finish(uchar &digest[]) {
         int block_nb;
         int pm_len;
-        int len_b;
+        ulong len_b;
         int i;
         block_nb = 1 + ((SHA384_512_BLOCK_SIZE - 17) < (m_len % SHA384_512_BLOCK_SIZE));
         len_b = (m_tot_len + m_len) << 3;
         pm_len = block_nb * SHA384_512_BLOCK_SIZE;
         for (int k = m_len; k < pm_len; ++k) m_block[k] = 0;
         m_block[m_len] = 0x80;
+        m_block[pm_len - 8] = (uchar)((len_b >> 56) & 0xFF);
+        m_block[pm_len - 7] = (uchar)((len_b >> 48) & 0xFF);
+        m_block[pm_len - 6] = (uchar)((len_b >> 40) & 0xFF);
+        m_block[pm_len - 5] = (uchar)((len_b >> 32) & 0xFF);
         m_block[pm_len - 4] = (uchar)((len_b >> 24) & 0xFF);
         m_block[pm_len - 3] = (uchar)((len_b >> 16) & 0xFF);
         m_block[pm_len - 2] = (uchar)((len_b >> 8) & 0xFF);


### PR DESCRIPTION
## Summary
- Write 64-bit message length during SHA-256 padding
- Track total processed length with 64-bit counter
- Fix MQL SHA256/SHA512 to emit full message length

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b8a61fe540832c82147f9d43e14395