### PR TITLE
Define headers for CMake installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,16 @@ set(HMAC_SOURCES
     sha1.cpp
 	sha256.cpp
     sha512.cpp
-	hmac.cpp
-	hmac_utils.cpp
+        hmac.cpp
+        hmac_utils.cpp
+)
+
+set(HMAC_HEADERS
+    hmac.hpp
+    hmac_utils.hpp
+    sha1.hpp
+    sha256.hpp
+    sha512.hpp
 )
 
 add_library(hmac STATIC ${HMAC_SOURCES})


### PR DESCRIPTION
## Summary
- Define `HMAC_HEADERS` variable listing public header files for installation
- Ensure `install(FILES ... DESTINATION include/hmac_cpp)` uses `HMAC_HEADERS`

## Testing
- `cmake -DBUILD_TESTS=ON ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68b8ab8ef500832c8589c72bca489173