### PR TITLE
Include algorithm header for std::fill usage

### DIFF
--- a/hmac.cpp
+++ b/hmac.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "hmac.hpp"
 
 namespace hmac {

--- a/sha1.cpp
+++ b/sha1.cpp
@@ -19,6 +19,7 @@
  * Modified by NewYaroslav, 2025-04-15
  */
  
+#include <algorithm>
 #include "sha1.hpp"
 
 /* Help macros */

--- a/sha1.hpp
+++ b/sha1.hpp
@@ -20,6 +20,7 @@
 #ifndef _HMAC_SHA1_HPP_INCLUDED
 #define _HMAC_SHA1_HPP_INCLUDED
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <cstdint>

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -39,6 +39,7 @@
  * Исправления: 18.06.2020 Elektro Yar
  */
 
+#include <algorithm>
 #include <cstring>
 //#include <fstream>
 #include "sha256.hpp"

--- a/sha256.hpp
+++ b/sha256.hpp
@@ -42,6 +42,7 @@
 #ifndef _HMAC_SHA256_HPP_INCLUDED
 #define _HMAC_SHA256_HPP_INCLUDED
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <cstdint>

--- a/sha512.cpp
+++ b/sha512.cpp
@@ -39,6 +39,7 @@
  * Исправления: 18.06.2020 Elektro Yar
  */
 
+#include <algorithm>
 #include <cstring>
 #include "sha512.hpp"
 

--- a/sha512.hpp
+++ b/sha512.hpp
@@ -42,6 +42,7 @@
 #ifndef _HMAC_SHA512_HPP_INCLUDED
 #define _HMAC_SHA512_HPP_INCLUDED
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include <cstdint>


### PR DESCRIPTION
## Summary
- add `<algorithm>` to HMAC and SHA source and header files so `std::fill` is defined

## Testing
- `g++ -std=c++17 -Wall -Wextra -pedantic -c hmac.cpp sha1.cpp sha256.cpp sha512.cpp example.cpp`
- `g++ -std=c++17 -Wall -Wextra -pedantic -c -x c++ - <<'EOF' && echo "templates compiled"
#include "sha1.hpp"
#include "sha256.hpp"
#include "sha512.hpp"
int main(){
    std::vector<uint8_t> v(1);
    auto r1 = hmac_hash::sha1(v);
    auto r2 = hmac_hash::sha256(v);
    auto r3 = hmac_hash::sha512(v);
    (void)r1; (void)r2; (void)r3;
    return 0;
}
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68b8accab1c8832c80422e3595c6c439