### PR TITLE
docs: add agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+## Commit Messages
+
+- Use Conventional Commits format: `type(scope): summary`.
+- The header must be in English.
+- Include a body that describes the change.
+
+## Changes
+
+- Keep diffs minimal and focused.
+- Do not refactor or apply style changes beyond the lines you directly touch.
+
+## Tooling
+
+- Run tests before committing changes.


### PR DESCRIPTION
## Summary
- add AGENTS instructions for commit format, focused diffs, and required testing

## Testing
- `cmake -B build -DBUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`


------
https://chatgpt.com/codex/tasks/task_e_68b8affc43dc832cbeffd8f087bba668