### PR TITLE
Replace Elektro Yar with NewYaroslav

### DIFF
--- a/sha256.cpp
+++ b/sha256.cpp
@@ -36,7 +36,7 @@
  */
 
 /* Оригинал кода: http://www.zedwood.com/article/cpp-sha256-function
- * Исправления: 18.06.2020 Elektro Yar
+ * Исправления: 18.06.2020 NewYaroslav
  */
 
 #include <cstring>

--- a/sha256.hpp
+++ b/sha256.hpp
@@ -36,7 +36,7 @@
  */
 
 /* Based on: http://www.zedwood.com/article/cpp-sha256-function
- * Modified by Elektro Yar, 2020-06-18
+ * Modified by NewYaroslav, 2020-06-18
  */
  
 #ifndef _HMAC_SHA256_HPP_INCLUDED

--- a/sha512.cpp
+++ b/sha512.cpp
@@ -36,7 +36,7 @@
  */
 
 /* Оригинал кода: http://www.zedwood.com/article/cpp-sha512-function
- * Исправления: 18.06.2020 Elektro Yar
+ * Исправления: 18.06.2020 NewYaroslav
  */
 
 #include <cstring>

--- a/sha512.hpp
+++ b/sha512.hpp
@@ -36,7 +36,7 @@
  */
 
 /* Based on: http://www.zedwood.com/article/cpp-sha512-function
- * Modified by Elektro Yar, 2020-06-18
+ * Modified by NewYaroslav, 2020-06-18
  */
 
 #ifndef _HMAC_SHA512_HPP_INCLUDED


### PR DESCRIPTION
## Summary
- Update comment headers to use the NewYaroslav name instead of Elektro Yar.

## Testing
- `cmake -B build -DBUILD_EXAMPLE=ON`
- `cmake --build build`
- `./build/example`


------
https://chatgpt.com/codex/tasks/task_e_68b8af6027b0832c856042e2a5989aa2