### PR TITLE
Use std::snprintf for SHA hex formatting

### DIFF
--- a/sha1.cpp
+++ b/sha1.cpp
@@ -18,7 +18,8 @@
 /* Based on: http://www.zedwood.com/article/cpp-sha1-function
  * Modified by NewYaroslav, 2025-04-15
  */
- 
+
+#include <cstdio>
 #include "sha1.hpp"
 
 /* Help macros */
@@ -246,7 +247,7 @@ namespace hmac_hash {
         char buf[2 * hmac_hash::SHA1::DIGEST_SIZE + 1];
         std::fill(buf, buf + (2 * hmac_hash::SHA1::DIGEST_SIZE + 1), '\0');
         for(size_t i = 0; i < hmac_hash::SHA1::DIGEST_SIZE; ++i) {
-            sprintf(buf + i * 2, "%02x", digest[i]);
+            std::snprintf(buf + i * 2, sizeof(buf) - i * 2, "%02x", digest[i]);
         }
         return std::string(buf, (2 * hmac_hash::SHA1::DIGEST_SIZE));
     }

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -40,6 +40,7 @@
  */
 
 #include <cstring>
+#include <cstdio>
 //#include <fstream>
 #include "sha256.hpp"
 
@@ -205,7 +206,7 @@ namespace hmac_hash {
         char buf[2 * hmac_hash::SHA256::DIGEST_SIZE + 1];
         std::fill(buf, buf + (2 * hmac_hash::SHA256::DIGEST_SIZE + 1), '\0');
         for(size_t i = 0; i < hmac_hash::SHA256::DIGEST_SIZE; ++i) {
-            sprintf(buf + i * 2, "%02x", digest[i]);
+            std::snprintf(buf + i * 2, sizeof(buf) - i * 2, "%02x", digest[i]);
         }
         return std::string(buf, (2 * hmac_hash::SHA256::DIGEST_SIZE));
     }

--- a/sha512.cpp
+++ b/sha512.cpp
@@ -40,6 +40,7 @@
  */
 
 #include <cstring>
+#include <cstdio>
 #include "sha512.hpp"
 
 #define SHA2_SHFR(x, n)    (x >> n)
@@ -240,7 +241,7 @@ namespace hmac_hash {
         char buf[2 * hmac_hash::SHA512::DIGEST_SIZE + 1];
         std::fill(buf, buf + (2 * hmac_hash::SHA512::DIGEST_SIZE + 1), '\0');
         for(size_t i = 0; i < hmac_hash::SHA512::DIGEST_SIZE; ++i){
-            sprintf(buf + i * 2, "%02x", digest[i]);
+            std::snprintf(buf + i * 2, sizeof(buf) - i * 2, "%02x", digest[i]);
         }
         return std::string(buf, (2 * hmac_hash::SHA512::DIGEST_SIZE));
     }


### PR DESCRIPTION
## Summary
- include `<cstdio>` for SHA modules
- replace `sprintf` with `std::snprintf` and remaining buffer size

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b8acb5522c832c9531042941f810bf