### PR TITLE
feat(utils): add constant-time token comparison

### DIFF
--- a/hmac_utils.hpp
+++ b/hmac_utils.hpp
@@ -7,6 +7,12 @@
 
 namespace hmac {
 
+    /// \brief Compares two strings in constant time
+    /// \param a First string
+    /// \param b Second string
+    /// \return true if both strings are equal
+    bool constant_time_equals(const std::string &a, const std::string &b);
+
     /// \brief Generates a time-based HMAC-SHA256 token
     /// \param key Secret key used for HMAC
     /// \param interval_sec Interval in seconds that defines token rotation. Must be positive. Default is 60 seconds


### PR DESCRIPTION
## Summary
- add constant_time_equals for byte-wise string comparison without early exit
- use constant_time_equals in token validation routines

## Testing
- `g++ -std=c++17 test_all.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -lgtest -lgtest_main -lpthread -o test_all && ./test_all`


------
https://chatgpt.com/codex/tasks/task_e_68b8b8d823b0832c8c0d4dd0cbcf004b