### PR TITLE
feat(utils): harden constant-time comparison

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -6,10 +6,12 @@
 namespace hmac {
  
     bool constant_time_equals(const std::string &a, const std::string &b) {
-        if (a.size() != b.size()) return false;
-        unsigned char diff = 0;
-        for (size_t i = 0; i < a.size(); ++i) {
-            diff |= static_cast<unsigned char>(a[i]) ^ static_cast<unsigned char>(b[i]);
+        size_t max_len = a.size() > b.size() ? a.size() : b.size();
+        unsigned char diff = static_cast<unsigned char>(a.size() ^ b.size());
+        for (size_t i = 0; i < max_len; ++i) {
+            unsigned char ac = i < a.size() ? static_cast<unsigned char>(a[i]) : 0;
+            unsigned char bc = i < b.size() ? static_cast<unsigned char>(b[i]) : 0;
+            diff |= ac ^ bc;
         }
         return diff == 0;
     }

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -23,6 +23,15 @@ TEST(UtilsTest, ToHex) {
     EXPECT_EQ(hmac::to_hex("012345"), "303132333435");
 }
 
+TEST(UtilsTest, ConstantTimeEqualsMatch) {
+    EXPECT_TRUE(hmac::constant_time_equals("alpha", "alpha"));
+}
+
+TEST(UtilsTest, ConstantTimeEqualsMismatch) {
+    EXPECT_FALSE(hmac::constant_time_equals("alpha", "beta"));
+    EXPECT_FALSE(hmac::constant_time_equals("alpha", "alphabet"));
+}
+
 TEST(HMACTest, SHA256) {
     const std::string key = "12345";
     const std::string input = "grape";


### PR DESCRIPTION
## Summary
- ensure constant_time_equals walks full string length without early exit
- test constant_time_equals for matching and mismatching inputs

## Testing
- `g++ -std=c++17 test_all.cpp hmac_utils.cpp hmac.cpp sha1.cpp sha256.cpp sha512.cpp -lgtest -lgtest_main -pthread -o test_all`
- `./test_all`
- `g++ -std=c++17 test_totp.cpp hmac_utils.cpp hmac.cpp sha1.cpp sha256.cpp sha512.cpp -pthread -o test_totp`
- `./test_totp`


------
https://chatgpt.com/codex/tasks/task_e_68b8c17e76a0832c82b1b3b2613f001e