### PR TITLE
Throw error for unsupported HMAC hash types

### DIFF
--- a/hmac.cpp
+++ b/hmac.cpp
@@ -102,7 +102,7 @@ namespace hmac {
                 digest_size = hmac_hash::SHA512::DIGEST_SIZE;
                 break;
             default:
-                return {};
+                throw std::invalid_argument("Unsupported hash type");
         }
 
         // Step 1: Normalize key

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -51,6 +51,13 @@ TEST(HMACTest, NullPointersThrow) {
     EXPECT_THROW(hmac::get_hmac(key, 3, nullptr, 1, hmac::TypeHash::SHA256), std::invalid_argument);
 }
 
+TEST(HMACTest, InvalidTypeThrows) {
+    const char* key = "key";
+    const char* msg = "abc";
+    auto invalid = static_cast<hmac::TypeHash>(999);
+    EXPECT_THROW(hmac::get_hmac(key, 3, msg, 3, invalid), std::invalid_argument);
+}
+
 TEST(TOTPTest, AtTime) {
     const std::string totp_key = "12345678901234567890";
     uint64_t test_time = 1234567890;


### PR DESCRIPTION
## Summary
- Raise `std::invalid_argument` when `get_hmac` receives an unsupported `TypeHash`
- Add unit test expecting an exception for invalid hash types

## Testing
- `g++ -std=c++17 test_all.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -lgtest -lgtest_main -pthread -o test_all && ./test_all`
- `g++ -std=c++17 test_totp.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -o test_totp && ./test_totp`


------
https://chatgpt.com/codex/tasks/task_e_68b8c172c940832c89e804a9291b5f97