### PR TITLE
fix(sha512): use 64-bit counters

### DIFF
--- a/sha512.cpp
+++ b/sha512.cpp
@@ -179,9 +179,9 @@ namespace hmac_hash {
         size_t block_nb;
         size_t new_len, rem_len, tmp_len;
         const uint8_t *shifted_message;
-        tmp_len = SHA384_512_BLOCK_SIZE - m_len;
+        tmp_len = SHA384_512_BLOCK_SIZE - static_cast<size_t>(m_len);
         rem_len = length < tmp_len ? length : tmp_len;
-        memcpy(&m_block[m_len], message, rem_len);
+        memcpy(&m_block[static_cast<size_t>(m_len)], message, rem_len);
         if((m_len + length) < SHA384_512_BLOCK_SIZE) {
             m_len += length;
             return;
@@ -194,7 +194,7 @@ namespace hmac_hash {
         rem_len = new_len % SHA384_512_BLOCK_SIZE;
         memcpy(m_block, &shifted_message[block_nb << 7], rem_len);
         m_len = rem_len;
-        m_tot_len += (block_nb + 1) << 7;
+        m_tot_len += static_cast<uint64_t>(block_nb + 1) << 7;
     }
 
     void SHA512::finish(uint8_t *digest) {
@@ -203,11 +203,11 @@ namespace hmac_hash {
         uint64_t len_b; // message length in bits
         size_t i;
         block_nb = (1 + ((SHA384_512_BLOCK_SIZE - 9)
-            < (m_len % SHA384_512_BLOCK_SIZE)));
+            < (static_cast<size_t>(m_len) % SHA384_512_BLOCK_SIZE)));
         len_b = (m_tot_len + m_len) << 3;
         pm_len = block_nb << 7;
-        memset(m_block + m_len, 0, pm_len - m_len);
-        m_block[m_len] = 0x80;
+        memset(m_block + static_cast<size_t>(m_len), 0, pm_len - static_cast<size_t>(m_len));
+        m_block[static_cast<size_t>(m_len)] = 0x80;
         SHA2_UNPACK64(len_b, m_block + pm_len - 8);
         transform(m_block, block_nb);
         for(i = 0 ; i < 8; ++i) {

--- a/sha512.hpp
+++ b/sha512.hpp
@@ -76,8 +76,8 @@ namespace hmac_hash {
 
     protected:
         void transform(const uint8_t *message, size_t block_nb);
-        size_t m_tot_len;
-        size_t m_len;
+        uint64_t m_tot_len;
+        uint64_t m_len;
         uint8_t m_block[2 * SHA384_512_BLOCK_SIZE];
         uint64_t m_h[8];
     };

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <string>
 #include <stdexcept>
+#include <vector>
 #include "hmac.hpp"
 #include "hmac_utils.hpp"
 
@@ -17,6 +18,23 @@ TEST(HashTest, SHA256) {
 TEST(HashTest, SHA512) {
     EXPECT_EQ(hmac_hash::sha512("grape"),
               "9375d1abdb644a01955bccad12e2f5c2bd8a3e226187e548d99c559a99461453b980123746753d07c169c22a5d9cc75cb158f0e8d8c0e713559775b5e1391fc4");
+}
+
+TEST(HashTest, SHA512LargeInput) {
+    hmac_hash::SHA512 ctx;
+    ctx.init();
+    std::vector<uint8_t> chunk(1024 * 1024, 'a');
+    for (size_t i = 0; i < 4096; ++i) {
+        ctx.update(chunk.data(), chunk.size());
+    }
+    uint8_t tail = 'b';
+    ctx.update(&tail, 1);
+
+    uint8_t digest[hmac_hash::SHA512::DIGEST_SIZE];
+    ctx.finish(digest);
+    std::string result(reinterpret_cast<char*>(digest), hmac_hash::SHA512::DIGEST_SIZE);
+    EXPECT_EQ(hmac::to_hex(result),
+              "596d71e02b4eca81f668215d3e9b9e5a143a9c3d8d1981608e0811b20e290961ec2a7e7ecd0e275366cf10aa5f7ab1e052b868c5fa57b6d2bd6e75477b2ecea7");
 }
 
 TEST(UtilsTest, ToHex) {


### PR DESCRIPTION
## Summary
- change SHA512 length counters to uint64_t and handle arithmetic accordingly
- add regression test for hashing data larger than 4GB

## Testing
- `g++ -std=c++17 test_all.cpp sha512.cpp sha256.cpp sha1.cpp hmac_utils.cpp hmac.cpp -lgtest -lgtest_main -lpthread -o test_all`
- `./test_all >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8c14560ec832cac29da62a5872fe1