### PR TITLE
fix(hash): throw on unsupported hash type

### DIFF
--- a/hmac.cpp
+++ b/hmac.cpp
@@ -47,9 +47,9 @@ namespace hmac {
                 ctx.finish(digest);
                 return std::string((const char*)digest, hmac_hash::SHA512::DIGEST_SIZE);
             }
-            default: break;
+            default:
+                throw std::invalid_argument("Unsupported hash type");
         };
-        return std::string();
     }
 
     std::vector<uint8_t> get_hash(const void* data, size_t length, TypeHash type) {
@@ -78,7 +78,8 @@ namespace hmac {
                 ctx.finish(digest.data());
                 return digest;
             }
-            default: return {};
+            default:
+                throw std::invalid_argument("Unsupported hash type");
         }
     }
 
@@ -150,7 +151,7 @@ namespace hmac {
             block_size = hmac_hash::SHA512::SHA384_512_BLOCK_SIZE;
             break;
         default:
-            return std::string();
+            throw std::invalid_argument("Unsupported hash type");
         };
 
         std::string key = key_input;

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -45,6 +45,17 @@ TEST(HashTest, SHA512LargeInput) {
               "596d71e02b4eca81f668215d3e9b9e5a143a9c3d8d1981608e0811b20e290961ec2a7e7ecd0e275366cf10aa5f7ab1e052b868c5fa57b6d2bd6e75477b2ecea7");
 }
 
+TEST(HashTest, InvalidTypeThrowsString) {
+    auto invalid = static_cast<hmac::TypeHash>(999);
+    EXPECT_THROW(hmac::get_hash("grape", invalid), std::invalid_argument);
+}
+
+TEST(HashTest, InvalidTypeThrowsBuffer) {
+    auto invalid = static_cast<hmac::TypeHash>(999);
+    const char data[] = "grape";
+    EXPECT_THROW(hmac::get_hash(data, sizeof(data) - 1, invalid), std::invalid_argument);
+}
+
 TEST(UtilsTest, ToHex) {
     EXPECT_EQ(hmac::to_hex("012345"), "303132333435");
 }
@@ -91,6 +102,13 @@ TEST(HMACTest, InvalidTypeThrows) {
     const char* msg = "abc";
     auto invalid = static_cast<hmac::TypeHash>(999);
     EXPECT_THROW(hmac::get_hmac(key, 3, msg, 3, invalid), std::invalid_argument);
+}
+
+TEST(HMACTest, InvalidTypeThrowsString) {
+    const std::string key = "key";
+    const std::string msg = "abc";
+    auto invalid = static_cast<hmac::TypeHash>(999);
+    EXPECT_THROW(hmac::get_hmac(key, msg, invalid), std::invalid_argument);
 }
 
 TEST(TOTPTest, AtTime) {


### PR DESCRIPTION
## Summary
- throw `std::invalid_argument` for unsupported hash type in hash and HMAC helpers
- add tests covering out-of-range `TypeHash`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8ca9bf2d8832c862365d7de17e50f