### PR TITLE
fix(utils): detect time failures via errno

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -1,5 +1,6 @@
 #include "hmac_utils.hpp"
 #include <ctime>
+#include <cerrno>
 #include <stdexcept>
 #include <limits>
 
@@ -20,8 +21,9 @@ namespace hmac {
         if (interval_sec <= 0) {
             throw std::invalid_argument("interval_sec must be positive");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         std::time_t rounded = (now / interval_sec) * interval_sec;
@@ -32,8 +34,9 @@ namespace hmac {
         if (interval_sec <= 0) {
             throw std::invalid_argument("interval_sec must be positive");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         std::time_t rounded = (now / interval_sec) * interval_sec;
@@ -51,8 +54,9 @@ namespace hmac {
         if (interval_sec <= 0) {
             throw std::invalid_argument("interval_sec must be positive");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         std::time_t rounded = (now / interval_sec) * interval_sec;
@@ -64,8 +68,9 @@ namespace hmac {
         if (interval_sec <= 0) {
             throw std::invalid_argument("interval_sec must be positive");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         std::time_t rounded = (now / interval_sec) * interval_sec;
@@ -144,8 +149,9 @@ namespace hmac {
         if (digits < 1 || digits > 9) {
             throw std::invalid_argument("TOTP: digits must be in range [1, 9]");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         uint64_t timestamp = static_cast<uint64_t>(now);
@@ -192,8 +198,9 @@ namespace hmac {
         if (digits < 1 || digits > 9) {
             throw std::invalid_argument("TOTP: digits must be in range [1, 9]");
         }
+        errno = 0;
         std::time_t now = std::time(nullptr);
-        if (now == static_cast<std::time_t>(-1)) {
+        if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
         uint64_t timestamp = static_cast<uint64_t>(now);

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -3,13 +3,16 @@
 #include <stdexcept>
 #include <vector>
 #include <limits>
+#include <cerrno>
 
 #include "hmac.hpp"
 #include "hmac_utils.hpp"
 
 static std::time_t mock_time_value = 0;
+static int mock_errno_value = 0;
 extern "C" std::time_t time(std::time_t* t) {
     if (t) *t = mock_time_value;
+    errno = mock_errno_value;
     return mock_time_value;
 }
 
@@ -155,6 +158,44 @@ TEST(TokenBoundaryFingerprintTest, MinTime) {
     std::string token_next = hmac::generate_time_token(key, fingerprint, interval);
     mock_time_value = std::numeric_limits<std::time_t>::min();
     EXPECT_TRUE(hmac::is_token_valid(token_next, key, fingerprint, interval));
+}
+
+TEST(TimeErrorTest, MinusOneNoErrno) {
+    const std::string key = "12345";
+    mock_time_value = static_cast<std::time_t>(-1);
+    mock_errno_value = 0;
+    std::string token;
+    EXPECT_NO_THROW(token = hmac::generate_time_token(key));
+    EXPECT_EQ(token, hmac::get_hmac(key, "0", hmac::TypeHash::SHA256));
+    mock_time_value = 0;
+    mock_errno_value = 0;
+}
+
+TEST(TimeErrorTest, MinusOneWithErrno) {
+    const std::string key = "12345";
+    mock_time_value = static_cast<std::time_t>(-1);
+    mock_errno_value = EINVAL;
+    EXPECT_THROW(hmac::generate_time_token(key), std::runtime_error);
+    mock_errno_value = 0;
+    mock_time_value = 0;
+}
+
+TEST(TotpTimeErrorTest, MinusOneNoErrno) {
+    const std::string key = "12345";
+    mock_time_value = static_cast<std::time_t>(-1);
+    mock_errno_value = 0;
+    EXPECT_NO_THROW(hmac::get_totp_code(key));
+    mock_time_value = 0;
+    mock_errno_value = 0;
+}
+
+TEST(TotpTimeErrorTest, MinusOneWithErrno) {
+    const std::string key = "12345";
+    mock_time_value = static_cast<std::time_t>(-1);
+    mock_errno_value = EINVAL;
+    EXPECT_THROW(hmac::get_totp_code(key), std::runtime_error);
+    mock_errno_value = 0;
+    mock_time_value = 0;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- use errno to distinguish real failures when std::time returns -1
- add tests for time returning -1 with and without error flag

## Testing
- `g++ -std=c++17 test_all.cpp hmac.cpp hmac_utils.cpp sha1.cpp sha256.cpp sha512.cpp -lgtest -pthread -o test_all`
- `./test_all`


------
https://chatgpt.com/codex/tasks/task_e_68b8cab719a8832c8ba2dc65188a59b3