### PR TITLE
fix(utils): use wider diff type for constant_time_equals

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -7,7 +7,7 @@ namespace hmac {
  
     bool constant_time_equals(const std::string &a, const std::string &b) {
         size_t max_len = a.size() > b.size() ? a.size() : b.size();
-        unsigned char diff = static_cast<unsigned char>(a.size() ^ b.size());
+        unsigned int diff = (a.size() != b.size());
         for (size_t i = 0; i < max_len; ++i) {
             unsigned char ac = i < a.size() ? static_cast<unsigned char>(a[i]) : 0;
             unsigned char bc = i < b.size() ? static_cast<unsigned char>(b[i]) : 0;

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -58,6 +58,14 @@ TEST(UtilsTest, ConstantTimeEqualsMismatch) {
     EXPECT_FALSE(hmac::constant_time_equals("alpha", "alphabet"));
 }
 
+TEST(UtilsTest, ConstantTimeEqualsLengthMultiples256) {
+    std::string base(256, 'a');
+    std::string plus256 = base + std::string(256, '\0');
+    std::string plus512 = base + std::string(512, '\0');
+    EXPECT_FALSE(hmac::constant_time_equals(base, plus256));
+    EXPECT_FALSE(hmac::constant_time_equals(base, plus512));
+}
+
 TEST(HMACTest, SHA256) {
     const std::string key = "12345";
     const std::string input = "grape";


### PR DESCRIPTION
## Summary
- avoid diff truncation in constant_time_equals by using unsigned int and boolean comparison
- test constant_time_equals for lengths differing by 256 and 512 bytes

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8ca8f0518832c9679c70e45fbd4fc