### PR TITLE
fix: guard HOTP against short digests

### DIFF
--- a/hmac_utils.hpp
+++ b/hmac_utils.hpp
@@ -81,6 +81,15 @@ namespace hmac {
     inline int get_hotp_code(const std::string& key, uint64_t counter, int digits = 6, TypeHash hash_type = TypeHash::SHA1) {
         return get_hotp_code(key.data(), key.size(), counter, digits, hash_type);
     }
+
+    namespace detail {
+        /// \brief Computes HOTP code from a precomputed HMAC digest
+        /// \param hmac_result HMAC digest bytes
+        /// \param digits Desired number of digits in the OTP (1-9)
+        /// \return One-Time Password (OTP) as an integer
+        /// \throws std::runtime_error if the digest is too short for dynamic truncation
+        int hotp_from_digest(const std::vector<uint8_t>& hmac_result, int digits);
+    }
     
     /// \brief Computes TOTP (Time-Based One-Time Password) code for a specific timestamp
     ///        Implements RFC 6238

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -131,6 +131,11 @@ TEST(HMACTest, InvalidTypeThrowsString) {
     EXPECT_THROW(hmac::get_hmac(key, msg, invalid), std::invalid_argument);
 }
 
+TEST(HOTPTest, ShortDigestThrows) {
+    std::vector<uint8_t> short_digest = {0x00, 0x01, 0x02};
+    EXPECT_THROW(hmac::detail::hotp_from_digest(short_digest, 6), std::runtime_error);
+}
+
 TEST(TOTPTest, AtTime) {
     const std::string totp_key = "12345678901234567890";
     uint64_t test_time = 1234567890;


### PR DESCRIPTION
## Summary
- ensure HOTP truncation checks digest length
- cover short digest path with unit test

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8d3ef346c832cacc3b9c3e1c7a285