### PR TITLE
fix(totp): handle negative time and refine rounding

### DIFF
--- a/hmac_utils.cpp
+++ b/hmac_utils.cpp
@@ -26,7 +26,7 @@ namespace hmac {
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
-        std::time_t rounded = (now / interval_sec) * interval_sec;
+        std::time_t rounded = now - (now % interval_sec);
         return get_hmac(key, std::to_string(rounded), hash_type);
     }
 
@@ -39,7 +39,7 @@ namespace hmac {
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
-        std::time_t rounded = (now / interval_sec) * interval_sec;
+        std::time_t rounded = now - (now % interval_sec);
         if (constant_time_equals(token, get_hmac(key, std::to_string(rounded), hash_type))) return true;
         if (rounded >= std::numeric_limits<std::time_t>::min() + interval_sec) {
             if (constant_time_equals(token, get_hmac(key, std::to_string(rounded - interval_sec), hash_type))) return true;
@@ -59,7 +59,7 @@ namespace hmac {
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
-        std::time_t rounded = (now / interval_sec) * interval_sec;
+        std::time_t rounded = now - (now % interval_sec);
         std::string payload = std::to_string(rounded) + "|" + fingerprint;
         return get_hmac(key, payload, hash_type);
     }
@@ -73,7 +73,7 @@ namespace hmac {
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
-        std::time_t rounded = (now / interval_sec) * interval_sec;
+        std::time_t rounded = now - (now % interval_sec);
         std::string prefix = "|" + fingerprint;
         std::string payload = std::to_string(rounded) + prefix;
         if (constant_time_equals(token, get_hmac(key, payload, hash_type))) return true;
@@ -154,6 +154,9 @@ namespace hmac {
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
         }
+        if (now < 0) {
+            throw std::runtime_error("std::time returned negative value");
+        }
         uint64_t timestamp = static_cast<uint64_t>(now);
         return get_totp_code_at(key_ptr, key_len, timestamp, period, digits, hash_type);
     }
@@ -202,6 +205,9 @@ namespace hmac {
         std::time_t now = std::time(nullptr);
         if (now == static_cast<std::time_t>(-1) && errno != 0) {
             throw std::runtime_error("std::time failed");
+        }
+        if (now < 0) {
+            throw std::runtime_error("std::time returned negative value");
         }
         uint64_t timestamp = static_cast<uint64_t>(now);
         uint64_t counter = timestamp / period;

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -215,22 +215,33 @@ TEST(TimeErrorTest, MinusOneWithErrno) {
     mock_time_value = 0;
 }
 
-TEST(TotpTimeErrorTest, MinusOneNoErrno) {
+TEST(TotpTimeErrorTest, NegativeTimeThrows) {
     const std::string key = "12345";
     mock_time_value = static_cast<std::time_t>(-1);
     mock_errno_value = 0;
-    EXPECT_NO_THROW(hmac::get_totp_code(key));
+    EXPECT_THROW(hmac::get_totp_code(key), std::runtime_error);
     mock_time_value = 0;
     mock_errno_value = 0;
 }
 
-TEST(TotpTimeErrorTest, MinusOneWithErrno) {
+TEST(TotpTimeErrorTest, NegativeTimeThrowsErrno) {
     const std::string key = "12345";
     mock_time_value = static_cast<std::time_t>(-1);
     mock_errno_value = EINVAL;
     EXPECT_THROW(hmac::get_totp_code(key), std::runtime_error);
     mock_errno_value = 0;
     mock_time_value = 0;
+}
+
+TEST(TotpTimeErrorTest, ValidityNegativeTimeThrows) {
+    const std::string key = "12345";
+    mock_time_value = static_cast<std::time_t>(-1);
+    mock_errno_value = 0;
+    EXPECT_THROW(
+        hmac::is_totp_token_valid(0, key.data(), key.size(), 30, 6, hmac::TypeHash::SHA1),
+        std::runtime_error);
+    mock_time_value = 0;
+    mock_errno_value = 0;
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Summary
- handle negative std::time_t in TOTP code paths
- round time using modulo to avoid truncation
- test negative time rejection

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b8d3ec2458832c933367cbcf2e430d