### PR TITLE
ci(workflows): run ctest

### DIFF
--- a/.github/workflows/CI-Linux.yml
+++ b/.github/workflows/CI-Linux.yml
@@ -20,7 +20,11 @@ jobs:
         std: [11, 17]
     steps:
       - uses: actions/checkout@v3
-      - name: Build and Run Tests
-        run: |
-          sudo apt-get update && sudo apt-get install -y cmake
-          CXX_STANDARD=${{ matrix.std }} ./scripts/run_tests.sh
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build
+      - name: Run tests
+        run: cd build && ctest --output-on-failure

--- a/.github/workflows/CI-Linux.yml
+++ b/.github/workflows/CI-Linux.yml
@@ -28,3 +28,18 @@ jobs:
         run: cmake --build build
       - name: Run tests
         run: cd build && ctest --output-on-failure
+  vcpkg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.sh
+          ./vcpkg/vcpkg install gtest
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+      - name: Build
+        run: cmake --build build
+      - name: Run tests
+        run: cd build && ctest --output-on-failure

--- a/.github/workflows/CI-Win.yml
+++ b/.github/workflows/CI-Win.yml
@@ -28,8 +28,12 @@ jobs:
             mingw-w64-x86_64-toolchain
             mingw-w64-x86_64-cmake
             mingw-w64-x86_64-make
-      - name: Build and Run Tests
+      - name: Configure
         shell: msys2 {0}
-        run: |
-          export CXX_STANDARD=${{ matrix.std }}
-          ./scripts/run_tests.sh
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        shell: msys2 {0}
+        run: cmake --build build
+      - name: Run tests
+        shell: msys2 {0}
+        run: ctest --test-dir build --output-on-failure


### PR DESCRIPTION
## Summary
- run ctest for Linux and Windows GitHub Actions
- install dependencies and configure tests via CMake

## Testing
- `./build/test_all --gtest_filter=HashTest.SHA1`


------
https://chatgpt.com/codex/tasks/task_e_68b9e25ac678832cb5179769867178fa