### PR TITLE
build: pin GoogleTest release for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,9 @@ if(BUILD_TESTS)
     include(FetchContent)
     FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/refs/heads/main.zip
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.14.0
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
     )
     FetchContent_MakeAvailable(googletest)
     add_executable(test_all test_all.cpp)


### PR DESCRIPTION
## Summary
- pin GoogleTest to v1.14.0 in FetchContent and preserve archive timestamps

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68ba134b3830832c89834d0aa62b83e0