### PR TITLE
feat(pbkdf2): enforce iteration limit

### DIFF
--- a/include/hmac_cpp/hmac_utils.hpp
+++ b/include/hmac_cpp/hmac_utils.hpp
@@ -6,7 +6,13 @@
 #include <string>
 #include <vector>
 
+#ifndef HMAC_CPP_MAX_PBKDF2_ITERATIONS
+#define HMAC_CPP_MAX_PBKDF2_ITERATIONS 1000000u
+#endif
+
 namespace hmac_cpp {
+
+    static constexpr uint32_t MAX_PBKDF2_ITERATIONS = HMAC_CPP_MAX_PBKDF2_ITERATIONS;
 
     /// \brief Compares two byte arrays in constant time
     /// \param a Pointer to first array

--- a/src/hmac_utils.cpp
+++ b/src/hmac_utils.cpp
@@ -40,6 +40,8 @@ namespace hmac_cpp {
             throw std::invalid_argument("Null pointer with non-zero length");
         if (iterations < 1)
             throw std::invalid_argument("PBKDF2: iterations must be >= 1");
+        if (iterations > MAX_PBKDF2_ITERATIONS)
+            throw std::invalid_argument("PBKDF2: iterations too large");
         if (dk_len == 0)
             throw std::invalid_argument("PBKDF2: dk_len must be positive");
         if (salt_len < 16)
@@ -115,7 +117,8 @@ namespace hmac_cpp {
             (salt_len > 0 && salt_ptr == nullptr) ||
             out_ptr == nullptr)
             return false;
-        if (iterations < 1 || dk_len == 0 || salt_len < 16)
+        if (iterations < 1 || dk_len == 0 || salt_len < 16 ||
+            iterations > MAX_PBKDF2_ITERATIONS)
             return false;
 
         const size_t hlen = hmac_hash::SHA256::DIGEST_SIZE;

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -237,6 +237,13 @@ TEST(PBKDF2Validation, TooLargeDkLenThrows) {
     EXPECT_THROW(hmac::pbkdf2("password", salt, 1, too_large, hmac::Pbkdf2Hash::Sha1), std::invalid_argument);
 }
 
+TEST(PBKDF2Validation, IterationsLimit) {
+    std::string salt(16, 'a');
+    uint32_t limit = hmac::MAX_PBKDF2_ITERATIONS;
+    EXPECT_NO_THROW(hmac::pbkdf2("password", salt, limit - 1, 32, hmac::Pbkdf2Hash::Sha256));
+    EXPECT_THROW(hmac::pbkdf2("password", salt, limit + 1, 32, hmac::Pbkdf2Hash::Sha256), std::invalid_argument);
+}
+
 TEST(PBKDF2Test, SHA256WithValidSalt) {
     auto salt = from_hex("000102030405060708090a0b0c0d0e0f");
     std::string salt_str(salt.begin(), salt.end());
@@ -254,6 +261,14 @@ TEST(PBKDF2BufferApiTest, SHA256ArrayOutput) {
     std::vector<uint8_t> ref(32);
     ASSERT_TRUE(PKCS5_PBKDF2_HMAC("password", 8, salt.data(), salt.size(), 2, EVP_sha256(), ref.size(), ref.data()));
     EXPECT_TRUE(std::equal(out.begin(), out.end(), ref.begin()));
+}
+
+TEST(PBKDF2BufferApiTest, IterationsLimit) {
+    std::string salt(16, 'a');
+    std::array<uint8_t,32> out{};
+    uint32_t limit = hmac::MAX_PBKDF2_ITERATIONS;
+    EXPECT_TRUE(hmac::pbkdf2_hmac_sha256(std::string("password"), salt, limit - 1, out));
+    EXPECT_FALSE(hmac::pbkdf2_hmac_sha256(std::string("password"), salt, limit + 1, out));
 }
 
 // SHA512 vector from BoringSSL pbkdf_test.cc


### PR DESCRIPTION
## Summary
- add configurable MAX_PBKDF2_ITERATIONS constant
- validate pbkdf2 iteration count against the limit
- test acceptance below the cap and rejection above it

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb2c29736c832ca88556594be7d990