### PR TITLE
ci: add macOS and benchmark workflows

### DIFF
--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -1,0 +1,45 @@
+name: CI-macOS
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+      - stable
+  pull_request:
+    branches:
+      - main
+      - release/**
+      - codex/**
+
+jobs:
+  Tests-macOS:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        std: [11, 17]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: brew update && brew install cmake
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
+      - name: Build
+        run: cmake --build build
+      - name: Run tests
+        run: cd build && ctest --output-on-failure
+  vcpkg:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          ./vcpkg/bootstrap-vcpkg.sh
+          ./vcpkg/vcpkg install gtest
+      - name: Configure
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake
+      - name: Build
+        run: cmake --build build
+      - name: Run tests
+        run: cd build && ctest --output-on-failure

--- a/.github/workflows/CI-macOS.yml
+++ b/.github/workflows/CI-macOS.yml
@@ -21,7 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: brew update && brew install cmake
+        run: |
+          brew update
+          brew uninstall --ignore-dependencies cmake || true
+          brew install cmake
       - name: Configure
         run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_STANDARD=${{ matrix.std }}
       - name: Build

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,16 @@
+name: Benchmarks
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake hyperfine
+      - name: Run benchmarks
+        run: scripts/run_benchmarks.sh

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release
+cmake --build build-bench --config Release
+hyperfine "./build-bench/example"


### PR DESCRIPTION
## Summary
- add macOS CI workflow using clang and vcpkg
- add tag-triggered benchmark workflow using hyperfine

## Testing
- `scripts/run_tests.sh`
- `scripts/run_benchmarks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb4d66e894832cb9e53e534959207b