### PR TITLE
feat: add streaming HMAC context and generic PBKDF2

### DIFF
--- a/include/hmac_cpp/hmac.hpp
+++ b/include/hmac_cpp/hmac.hpp
@@ -50,6 +50,36 @@ namespace hmac_cpp {
         return get_hash(input.data(), input.size(), type);
     }
 
+    /// \brief Streaming HMAC computation context.
+    class HmacContext {
+    public:
+        explicit HmacContext(TypeHash type) : type_(type), block_size_(0), digest_size_(0) {}
+
+        /// \brief Initializes the context with a secret key.
+        /// \param key_ptr Pointer to the key buffer; must be non-null if key_len > 0
+        /// \param key_len Length of the key in bytes
+        void init(const void* key_ptr, size_t key_len);
+
+        /// \brief Updates the HMAC with message data.
+        /// \param data_ptr Pointer to the message buffer; must be non-null if data_len > 0
+        /// \param data_len Length of the message in bytes
+        void update(const void* data_ptr, size_t data_len);
+
+        /// \brief Finalizes the HMAC and writes the result to the provided buffer.
+        /// \param out_ptr Output buffer for the HMAC result
+        /// \param out_len Length of the output buffer; must be at least the digest size
+        void final(uint8_t* out_ptr, size_t out_len);
+
+    private:
+        TypeHash type_;
+        size_t block_size_;
+        size_t digest_size_;
+        secure_buffer<uint8_t> okeypad_;
+        hmac_hash::SHA1 sha1_;
+        hmac_hash::SHA256 sha256_;
+        hmac_hash::SHA512 sha512_;
+    };
+
     /// \brief Computes HMAC for raw binary data using the specified hash function.
     /// \param key_ptr Pointer to the key buffer; must be non-null if key_len > 0
     /// \param key_len Length of the key in bytes

--- a/include/hmac_cpp/hmac_utils.hpp
+++ b/include/hmac_cpp/hmac_utils.hpp
@@ -106,6 +106,55 @@ namespace hmac_cpp {
                       iterations, dk_len, prf);
     }
 
+    /// \brief Derives PBKDF2 into caller-provided buffer using selected hash.
+    /// \param prf Hash function to use (SHA1, SHA256, SHA512)
+    /// \param password_ptr Pointer to the password buffer
+    /// \param password_len Length of the password in bytes
+    /// \param salt_ptr Pointer to the salt buffer
+    /// \param salt_len Length of the salt in bytes
+    /// \param iterations Number of iterations, must be positive
+    /// \param out_ptr Output buffer for derived key
+    /// \param dk_len Length of output buffer in bytes, must be positive
+    /// \return true on success, false on invalid parameters
+    bool pbkdf2(Pbkdf2Hash prf,
+                const void* password_ptr, size_t password_len,
+                const void* salt_ptr, size_t salt_len,
+                uint32_t iterations, uint8_t* out_ptr, size_t dk_len) noexcept;
+
+    /// \deprecated Use overloads that accept std::vector<uint8_t> or secure_buffer.
+    template<size_t N>
+    HMACCPP_DEPRECATED("use std::vector<uint8_t> or secure_buffer overload")
+    inline bool pbkdf2(Pbkdf2Hash prf,
+                       const std::string& password,
+                       const std::string& salt,
+                       uint32_t iterations,
+                       std::array<uint8_t, N>& out) noexcept {
+        return pbkdf2(prf, password.data(), password.size(),
+                      salt.data(), salt.size(),
+                      iterations, out.data(), out.size());
+    }
+
+    inline bool pbkdf2(Pbkdf2Hash prf,
+                       const secure_buffer<uint8_t>& password,
+                       const secure_buffer<uint8_t>& salt,
+                       uint32_t iterations,
+                       uint8_t* out_ptr, size_t dk_len) noexcept {
+        return pbkdf2(prf, password.data(), password.size(),
+                      salt.data(), salt.size(),
+                      iterations, out_ptr, dk_len);
+    }
+
+    template<size_t N>
+    inline bool pbkdf2(Pbkdf2Hash prf,
+                       const secure_buffer<uint8_t>& password,
+                       const secure_buffer<uint8_t>& salt,
+                       uint32_t iterations,
+                       std::array<uint8_t, N>& out) noexcept {
+        return pbkdf2(prf, password.data(), password.size(),
+                      salt.data(), salt.size(),
+                      iterations, out.data(), out.size());
+    }
+
     /// \brief Derives PBKDF2-HMAC-SHA256 into caller-provided buffer
     /// \param password_ptr Pointer to the password buffer
     /// \param password_len Length of the password in bytes

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -306,6 +306,17 @@ TEST(PBKDF2BufferApiTest, SHA256ArrayOutput) {
     EXPECT_TRUE(std::equal(out.begin(), out.end(), ref.begin()));
 }
 
+TEST(PBKDF2BufferApiTest, GenericArrayOutput) {
+    auto salt = from_hex("000102030405060708090a0b0c0d0e0f");
+    std::string salt_str(salt.begin(), salt.end());
+    std::array<uint8_t,32> out{};
+    ASSERT_TRUE(hmac::pbkdf2(hmac::Pbkdf2Hash::Sha256,
+                             std::string("password"), salt_str, 2, out));
+    std::vector<uint8_t> ref(32);
+    ASSERT_TRUE(PKCS5_PBKDF2_HMAC("password", 8, salt.data(), salt.size(), 2, EVP_sha256(), ref.size(), ref.data()));
+    EXPECT_TRUE(std::equal(out.begin(), out.end(), ref.begin()));
+}
+
 TEST(PBKDF2BufferApiTest, IterationsLimit) {
     std::string salt(16, 'a');
     std::array<uint8_t,32> out{};


### PR DESCRIPTION
## Summary
- introduce `HmacContext` for incremental HMAC operations
- add generic `pbkdf2` buffer API and update wrapper
- extend tests to cover the new API

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bb4cc6a550832c88824fb410c6fab7