### PR TITLE
refactor(mql): rename hash enum values

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -67,8 +67,14 @@ _install/
 ```mql5
 #include <hmac-cpp/hmac.mqh>
 
-string hash = hmac::get_hmac("key", "message", hmac::TypeHash::HASH_SHA256);
+string hash = hmac::get_hmac("key", "message", hmac::TypeHash::SHA256);
 ```
+
+| Хеш-функция | Значение в C++           | Значение в MQL           |
+|-------------|--------------------------|--------------------------|
+| SHA1        | `hmac::TypeHash::SHA1`   | – (не доступно)          |
+| SHA256      | `hmac::TypeHash::SHA256` | `hmac::TypeHash::SHA256` |
+| SHA512      | `hmac::TypeHash::SHA512` | `hmac::TypeHash::SHA512` |
 
 ## Использование
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,14 @@ You can use the same interface inside your MQL5 scripts and experts:
 ```mql5
 #include <hmac-cpp/hmac.mqh>
 
-string hash = hmac::get_hmac("key", "message", hmac::TypeHash::HASH_SHA256);
+string hash = hmac::get_hmac("key", "message", hmac::TypeHash::SHA256);
 ```
+
+| Hash function | C++ enum              | MQL enum              |
+|---------------|----------------------|-----------------------|
+| SHA1          | `hmac::TypeHash::SHA1`| – (not available)     |
+| SHA256        | `hmac::TypeHash::SHA256` | `hmac::TypeHash::SHA256` |
+| SHA512        | `hmac::TypeHash::SHA512` | `hmac::TypeHash::SHA512` |
 
 ## Usage
 

--- a/hmac.mqh
+++ b/hmac.mqh
@@ -13,8 +13,8 @@ namespace hmac {
 
     /// \brief Type of the hash function used
     enum TypeHash {
-        HASH_SHA256 = 0, ///< Use SHA256
-        HASH_SHA512 = 1, ///< Use SHA512
+        SHA256 = 0, ///< Use SHA256
+        SHA512 = 1, ///< Use SHA512
     };
     
     /// \brief Converts a byte array to hexadecimal string
@@ -66,7 +66,7 @@ namespace hmac {
     /// \param type Hash function type
     void calc_hash(uchar &digest[], const uchar &data[], TypeHash type) {
         switch(type) {
-            case TypeHash::HASH_SHA256: {
+            case TypeHash::SHA256: {
                 ArrayResize(digest, SHA256_DIGEST_SIZE);
                 ArrayFill(digest, 0, SHA256_DIGEST_SIZE, 0);
                 hmac_hash::SHA256 ctx;
@@ -75,7 +75,7 @@ namespace hmac {
                 ctx.finish(digest);
                 break;
             }
-            case TypeHash::HASH_SHA512: {
+            case TypeHash::SHA512: {
                 ArrayResize(digest, SHA512_DIGEST_SIZE);
                 ArrayFill(digest, 0, SHA512_DIGEST_SIZE, 0);
                 hmac_hash::SHA512 ctx;
@@ -116,11 +116,11 @@ namespace hmac {
         int block_size = 0;
         int digest_size = 0;
         switch(type) {
-        case TypeHash::HASH_SHA256:
+        case TypeHash::SHA256:
             block_size = SHA224_256_BLOCK_SIZE;
             digest_size = SHA256_DIGEST_SIZE;
             break;
-        case TypeHash::HASH_SHA512:
+        case TypeHash::SHA512:
             block_size = SHA384_512_BLOCK_SIZE;
             digest_size = SHA512_DIGEST_SIZE;
             break;

--- a/hmac_utils.mqh
+++ b/hmac_utils.mqh
@@ -15,7 +15,7 @@ namespace hmac {
     /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
     /// \param hash_type Hash function to use. Default is SHA256
     /// \return Hex-encoded HMAC-SHA256 of the rounded time value
-    string generate_time_token(const string &key, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::HASH_SHA256) {
+    string generate_time_token(const string &key, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::SHA256) {
        datetime now = TimeGMT();
        datetime rounded = (now / interval_sec) * interval_sec;
        return hmac::get_hmac(key, IntegerToString(rounded), hash_type);
@@ -27,7 +27,7 @@ namespace hmac {
     /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
     /// \param hash_type Hash function to use. Default is SHA256
     /// \return true if the token is valid within the ±1 interval range; false otherwise
-    bool is_token_valid(const string &token, const string &key, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::HASH_SHA256) {
+    bool is_token_valid(const string &token, const string &key, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::SHA256) {
         datetime now = TimeGMT();
         datetime rounded = (now / interval_sec) * interval_sec;
         if (token == get_hmac(key, IntegerToString(rounded), hash_type)) return true;
@@ -42,7 +42,7 @@ namespace hmac {
     /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
     /// \param hash_type Hash function to use. Default is SHA256
     /// \return Hex-encoded HMAC-SHA256 of the concatenated timestamp and fingerprint
-    string generate_time_token(const string &key, const string &fingerprint, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::HASH_SHA256) {
+    string generate_time_token(const string &key, const string &fingerprint, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::SHA256) {
        datetime now = TimeGMT();
        datetime rounded = (now / interval_sec) * interval_sec;
        string payload = IntegerToString(rounded) + "|" + fingerprint;
@@ -56,7 +56,7 @@ namespace hmac {
     /// \param interval_sec Interval in seconds that defines token rotation. Default is 60 seconds
     /// \param hash_type Hash function to use. Default is SHA256
     /// \return true if the token is valid within the ±1 interval range; false otherwise
-    bool is_token_valid(const string &token, const string &key, const string &fingerprint, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::HASH_SHA256) {
+    bool is_token_valid(const string &token, const string &key, const string &fingerprint, int interval_sec = 60, hmac::TypeHash hash_type = hmac::TypeHash::SHA256) {
         datetime now = TimeGMT();
         datetime rounded = (now / interval_sec) * interval_sec;
         string prefix = "|" + fingerprint;

--- a/test_hmac.mq5
+++ b/test_hmac.mq5
@@ -11,7 +11,7 @@ void OnStart() {
     
     // SHA256
     print_section("SHA256");
-    string sha256_output_1 = hmac::get_hash(data, hmac::TypeHash::HASH_SHA256);
+    string sha256_output_1 = hmac::get_hash(data, hmac::TypeHash::SHA256);
     string sha256_output_2 = hmac_hash::sha256(data);
     Print("sha256('", data, "') = ", sha256_output_1);
     Print("sha256('", data, "') = ", sha256_output_2);
@@ -19,7 +19,7 @@ void OnStart() {
     
     // SHA512
     print_section("SHA512");
-    string sha512_output_1 = hmac::get_hash(data, hmac::TypeHash::HASH_SHA512);
+    string sha512_output_1 = hmac::get_hash(data, hmac::TypeHash::SHA512);
     string sha512_output_2 = hmac_hash::sha512(data);
     Print("sha512('", data, "') = ", sha512_output_1);
     Print("sha512('", data, "') = ", sha512_output_2);
@@ -32,19 +32,19 @@ void OnStart() {
     
     // HMAC-SHA256
     print_section("HMAC-SHA256");
-    string hmac_sha256 = hmac::get_hmac(key, data, hmac::TypeHash::HASH_SHA256);
+    string hmac_sha256 = hmac::get_hmac(key, data, hmac::TypeHash::SHA256);
     Print("HMAC('", key, "', '", data, "', SHA256) = ", hmac_sha256);
     Print("Expected: 7632ac2e8ddedaf4b3e7ab195fefd17571c37c970e02e169195a158ef59e53ca\n");
     
     // HMAC-SHA512
     print_section("HMAC-SHA512");
-    string hmac_sha512 = hmac::get_hmac(key, data, hmac::TypeHash::HASH_SHA512);
+    string hmac_sha512 = hmac::get_hmac(key, data, hmac::TypeHash::SHA512);
     Print("HMAC('", key, "', '", data, "', SHA512) = ", hmac_sha512);
     Print("Expected: c54ddf9647a949d0df925a1c1f8ba1c9d721a671c396fde1062a71f9f7ffae5dc10f6be15be63bb0363d051365e23f890368c54828497b9aef2eb2fc65b633e6\n");
     
     // HMAC-SHA512 uppercase hex
     print_section("HMAC-SHA512 (uppercase)");
-    string hmac_sha512_upper = hmac::get_hmac(key, data, hmac::TypeHash::HASH_SHA512, true);
+    string hmac_sha512_upper = hmac::get_hmac(key, data, hmac::TypeHash::SHA512, true);
     Print("HMAC('", key, "', '", data, "', SHA512, hex=true, upper=true) = ", hmac_sha512_upper);
     
     // HMAC-TIMED TOKEN


### PR DESCRIPTION
## Summary
- align MQL TypeHash enum values with C++ by renaming HASH_SHA256/HASH_SHA512 to SHA256/SHA512
- update MQL utilities, tests, and docs accordingly
- document hash enum mapping between C++ and MQL

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb6cf746f8832c842cb5c29cdd11c9