### PR TITLE
docs: clarify HMAC string overload usage

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -82,12 +82,11 @@ string hash = hmac::get_hmac("key", "message", hmac::TypeHash::SHA256);
 
 ```cpp
 std::string get_hmac(
-    std::string key,
+    const std::string& key,
     const std::string& msg,
-    const TypeHash type,
+    TypeHash type,
     bool is_hex = true,
-    bool is_upper = false
-);
+    bool is_upper = false);
 ```
 
 Параметры:
@@ -100,7 +99,7 @@ std::string get_hmac(
 
 Возвращает:
 Если `is_hex == true`, возвращает HMAC в виде hex-строки (`std::string`).
-Если `is_hex == false`, возвращает HMAC в виде бинарной строки (`std::string`, не предназначена для вывода).
+Если `is_hex == false`, возвращает бинарную строку; для бинарного вывода предпочтительнее перегрузка со `std::vector<uint8_t>`.
 
 #### Безопасная работа со строковыми ключами
 

--- a/README.md
+++ b/README.md
@@ -110,12 +110,11 @@ string hash = hmac::get_hmac("key", "message", hmac::TypeHash::SHA256);
 
 ```cpp
 std::string get_hmac(
-    std::string key,
+    const std::string& key,
     const std::string& msg,
-    const TypeHash type,
+    TypeHash type,
     bool is_hex = true,
-    bool is_upper = false
-);
+    bool is_upper = false);
 ```
 
 Parameters:
@@ -128,7 +127,7 @@ Parameters:
 
 Returns:
 If `is_hex == true`, returns a hexadecimal string (`std::string`) of the HMAC.
-If `is_hex == false`, returns a raw binary HMAC as a `std::string` (not human-readable).
+If `is_hex == false`, returns a raw binary string; for binary output, prefer the `std::vector<uint8_t>` overload.
 
 #### Secure handling of string keys
 


### PR DESCRIPTION
## Summary
- document const-reference HMAC string overload
- suggest using std::vector<uint8_t> overload for binary output

## Testing
- `bash scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bb70ba7284832caa18f2b80108aeb1