### PR TITLE
feat: add base36 encoding and expand tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,22 @@ bool v2 = hmac::is_token_valid(t2, secret_key, fingerprint, 60);
 
 ---
 
+### Encoding helpers
+
+`hmac_cpp::encoding` provides simple conversions:
+
+* **Base64** — standard `+/` and URL-safe `-_` alphabets; optional `strict` mode
+  (rejects whitespace and mixed padding) and ability to decode without `=`.
+* **Base32** — RFC 4648 alphabet `A–Z2–7`; encoder outputs upper-case, decoder
+  accepts lower-case and ignores spaces/CR/LF when `strict=false`.
+* **Base36** — non-standard human-readable IDs using `0–9A–Z`; keeps leading
+  zero bytes by prefixing `'0'` and maps a single `\x00` to "0".
+
+Returned strings and buffers are not zeroized; if you store secrets, prefer
+`secure_buffer` and wipe explicitly.
+
+---
+
 ## 📦 MQL5 Compatibility
 
 Repository provides `sha256.mqh`, `sha512.mqh`, `hmac.mqh`, `hmac_utils.mqh` (MetaTrader 5).

--- a/include/hmac_cpp/encoding.hpp
+++ b/include/hmac_cpp/encoding.hpp
@@ -45,8 +45,9 @@ namespace hmac_cpp {
     /// \param out Output byte vector (overwritten).
     /// \param alphabet Standard ("+/") or URL-safe ("-_") alphabet.
     /// \param require_padding If true, input must have proper '=' padding and length % 4 == 0.
-    /// \param strict If true, disallow whitespaces and enforce '=' only in the last quartet.
-    ///               If false, ignore ASCII spaces and CR/LF/TAB and allow missing padding.
+    /// \param strict If true, disallow whitespace and require '=' only in the last quartet.
+    ///               If false, ignore ASCII spaces/CR/LF/TAB, allow missing padding, and
+    ///               accept mixed "+/" and "-_" when \p alphabet == Url.
     /// \return true on success, false on invalid input.
     HMAC_CPP_API bool base64_decode(const std::string& in, std::vector<uint8_t>& out,
                                     Base64Alphabet alphabet = Base64Alphabet::Standard,
@@ -67,7 +68,7 @@ namespace hmac_cpp {
     /// \param data Pointer to input bytes.
     /// \param len  Number of input bytes.
     /// \param pad If true, append '=' padding to a multiple of 8 chars.
-    /// \return Encoded string (upper-case).
+    /// \return Encoded string (upper-case alphabet).
     HMAC_CPP_API std::string base32_encode(const uint8_t* data, size_t len,
                                            bool pad = true);
 
@@ -85,8 +86,8 @@ namespace hmac_cpp {
     /// \param in Input string (Base32; upper-case preferred).
     /// \param out Output byte vector (overwritten).
     /// \param require_padding If true, input must have proper '=' padding and length % 8 == 0.
-    /// \param strict If true, disallow whitespaces and lower-case; enforce '=' only in the last block.
-    ///               If false, ignore ASCII spaces and CR/LF/TAB and accept lower-case letters.
+    /// \param strict If true, disallow whitespace and lower-case; enforce '=' only in the last block.
+    ///               If false, ignore ASCII spaces/CR/LF/TAB and accept lower-case letters.
     /// \return true on success, false on invalid input.
     HMAC_CPP_API bool base32_decode(const std::string& in, std::vector<uint8_t>& out,
                                     bool require_padding = false,
@@ -96,6 +97,37 @@ namespace hmac_cpp {
     HMAC_CPP_API bool base32_decode(const std::string& in, secure_buffer<uint8_t>& out,
                                     bool require_padding = false,
                                     bool strict = true) noexcept;
+
+    // -------------------------
+    // Base36 — encode / decode
+    // -------------------------
+
+    /// \brief Base36-encode a byte buffer (digits 0–9, letters A–Z).
+    ///        Leading zero bytes are preserved by prefixing '0'.
+    ///        Input of a single \x00 returns "0".
+    /// \param data Pointer to input bytes (big-endian).
+    /// \param len  Number of input bytes.
+    /// \return Encoded string.
+    HMAC_CPP_API std::string base36_encode(const uint8_t* data, size_t len);
+
+    /// \brief Base36-encode a vector.
+    inline std::string base36_encode(const std::vector<uint8_t>& v) {
+        return base36_encode(v.data(), v.size());
+    }
+
+    /// \brief Base36-encode a secure_buffer.
+    inline std::string base36_encode(const secure_buffer<uint8_t>& v) {
+        return base36_encode(v.data(), v.size());
+    }
+
+    /// \brief Decode a Base36 string.
+    /// \param in  Input string (case-insensitive).
+    /// \param out Output byte vector (overwritten).
+    /// \return true on success, false on invalid input.
+    HMAC_CPP_API bool base36_decode(const std::string& in, std::vector<uint8_t>& out) noexcept;
+
+    /// \brief Decode Base36 into secure_buffer.
+    HMAC_CPP_API bool base36_decode(const std::string& in, secure_buffer<uint8_t>& out) noexcept;
 
 } // namespace hmac_cpp
 


### PR DESCRIPTION
## Summary
- add base36 encoder/decoder with leading-zero support
- accept mixed punctuation in URL-safe Base64 decoding
- document encoding behavior and zeroization caveat
- expand unit tests for Base64, Base32, and Base36

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68bb94828c60832c87f29eb590285e6d