### PR TITLE
Fix benchmark script to build example program

### DIFF
--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release
+cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release -DHMACCPP_BUILD_EXAMPLES=ON
 cmake --build build-bench --config Release
 hyperfine "./build-bench/example"


### PR DESCRIPTION
## Summary
- ensure benchmark script builds example so hyperfine can run

## Testing
- `./scripts/run_tests.sh`
- `./scripts/run_benchmarks.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bbabb19e14832c8aadafca75190394