### PR TITLE
docs: add changelog entry for 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
 ## [Unreleased]
+
+## [0.4.0] - 2025-09-06
 ### Added
-- Base64 and Base32 encoding/decoding utilities with secure_buffer overloads.
+- Base32 (RFC 4648), Base64, and Base36 encoding/decoding utilities.
+- `secure_buffer<T>` zeroizing container and helpers (page locking, secret_string).
+- Expanded HOTP/TOTP test coverage.
+
+### Changed
+- CMake install exports new headers.
+- README updated.
+
+### Notes
+- Breaking changes: none (public API only extended).
 
 ## [0.3.0] - 2025-09-05
 ### Added


### PR DESCRIPTION
## Summary
- document new Base32/Base64/Base36 encoding helpers
- mention secure_buffer container and HOTP/TOTP test coverage
- note build and README updates for 0.4.0

## Testing
- `./test_totp`

------
https://chatgpt.com/codex/tasks/task_e_68bbc93846d8832ca31a83b92c78b72d