### PR TITLE
docs(readme): add secret_string example

### DIFF
--- a/README-RU.md
+++ b/README-RU.md
@@ -141,6 +141,21 @@ secure_buffer key(std::move(secret_string)); // обнуляет перемещ�
 auto mac = hmac::get_hmac(key, payload, hmac::TypeHash::SHA256);
 ```
 
+Для дополнительной защиты в памяти можно использовать `hmac_cpp::secret_string`, который
+обфусцирует данные и по возможности закрепляет их в RAM:
+
+```cpp
+#include <hmac_cpp/secret.hpp>
+
+hmac_cpp::secret_string token("super-secret-token");
+
+token.with_plaintext([](const uint8_t* p, size_t n){
+    // p действует только внутри коллбэка
+});
+
+token.clear();
+```
+
 ### HMAC (сырой буфер)
 
 ```cpp

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ secure_buffer key(std::move(secret_string)); // zeroizes moved-from string
 auto mac = hmac::get_hmac(key, payload, hmac::TypeHash::SHA256);
 ```
 
+For additional protection in memory, `hmac_cpp::secret_string` obfuscates
+the data and tries to keep it locked in RAM:
+
+```cpp
+#include <hmac_cpp/secret.hpp>
+
+hmac_cpp::secret_string token("super-secret-token");
+
+token.with_plaintext([](const uint8_t* p, size_t n){
+    // p is valid only inside the callback
+});
+
+token.clear();
+```
+
 ### HMAC (raw buffer)
 
 ```cpp


### PR DESCRIPTION
## Summary
- add example demonstrating `hmac_cpp::secret_string` for extra in-memory protection
- mirror the example in the Russian README

## Testing
- `cmake -B build -DHMACCPP_BUILD_TESTS=ON`
- `cmake --build build`
- `./build/test_all`


------
https://chatgpt.com/codex/tasks/task_e_68bbc57eae14832ca6f35edd3f5ba047