### PR TITLE
refactor: rename secret header to secret_string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(HMAC_HEADERS
     include/hmac_cpp/sha512.hpp
     include/hmac_cpp/secure_buffer.hpp
     include/hmac_cpp/memlock.hpp
-    include/hmac_cpp/secret.hpp
+    include/hmac_cpp/secret_string.hpp
     include/hmac_cpp/encoding.hpp
     include/hmac_cpp/version.hpp
 )

--- a/README-RU.md
+++ b/README-RU.md
@@ -145,7 +145,7 @@ auto mac = hmac::get_hmac(key, payload, hmac::TypeHash::SHA256);
 обфусцирует данные и по возможности закрепляет их в RAM:
 
 ```cpp
-#include <hmac_cpp/secret.hpp>
+#include <hmac_cpp/secret_string.hpp>
 
 hmac_cpp::secret_string token("super-secret-token");
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For additional protection in memory, `hmac_cpp::secret_string` obfuscates
 the data and tries to keep it locked in RAM:
 
 ```cpp
-#include <hmac_cpp/secret.hpp>
+#include <hmac_cpp/secret_string.hpp>
 
 hmac_cpp::secret_string token("super-secret-token");
 

--- a/example_secret.cpp
+++ b/example_secret.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <hmac_cpp/secret.hpp>
+#include <hmac_cpp/secret_string.hpp>
 
 int main() {
     hmac_cpp::secret_string token("super-secret-token");

--- a/include/hmac_cpp/secret_string.hpp
+++ b/include/hmac_cpp/secret_string.hpp
@@ -1,5 +1,5 @@
-#ifndef HMAC_CPP_SECRET_HPP_INCLUDED
-#define HMAC_CPP_SECRET_HPP_INCLUDED
+#ifndef HMAC_CPP_SECRET_STRING_HPP_INCLUDED
+#define HMAC_CPP_SECRET_STRING_HPP_INCLUDED
 
 #include <vector>
 #include <array>
@@ -270,4 +270,4 @@ private:
 
 } // namespace hmac_cpp
 
-#endif // HMAC_CPP_SECRET_HPP_INCLUDED
+#endif // HMAC_CPP_SECRET_STRING_HPP_INCLUDED

--- a/test_all.cpp
+++ b/test_all.cpp
@@ -12,7 +12,7 @@
 #include "hmac_cpp/hmac.hpp"
 #include "hmac_cpp/hmac_utils.hpp"
 #include "hmac_cpp/encoding.hpp"
-#include "hmac_cpp/secret.hpp"
+#include "hmac_cpp/secret_string.hpp"
 
 static std::time_t mock_time_value = 0;
 static int mock_errno_value = 0;


### PR DESCRIPTION
## Summary
- rename `secret.hpp` to `secret_string.hpp`
- update includes, build config, and docs to use new header

## Testing
- `cmake -S . -B build -DHMACCPP_BUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bce759668c832c97cc3d08dfebdc85