### PR TITLE
feat(vcpkg): add vcpkg port for hmac-cpp

### DIFF
--- a/ports/hmac-cpp/portfile.cmake
+++ b/ports/hmac-cpp/portfile.cmake
@@ -1,0 +1,24 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO NewYaroslav/hmac-cpp
+    REF v0.5.0
+    SHA512 a4e4b137ea6dab0ae22990ba0c9c45a290e51dd454b1e5865c7e918dc53896388427deb0c1aa92936c8f36ef908d1fed1066c4dc77703401ef9e14b7c1dc0697
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    CONFIG_PATH lib/cmake/hmac_cpp
+)
+
+vcpkg_fixup_pkgconfig()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(
+    FILE_LIST "${SOURCE_PATH}/LICENSE"
+)

--- a/ports/hmac-cpp/vcpkg.json
+++ b/ports/hmac-cpp/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "name": "hmac-cpp",
+  "version": "0.5.0",
+  "homepage": "https://github.com/NewYaroslav/hmac-cpp",
+  "description": "C++ implementation of HMAC and SHA algorithms",
+  "license": "MIT",
+  "dependencies": [
+    "vcpkg-cmake",
+    "vcpkg-cmake-config"
+  ]
+}


### PR DESCRIPTION
## Summary
- add portfile and manifest to build hmac-cpp via vcpkg

## Testing
- `cmake -S . -B build -DHMACCPP_BUILD_TESTS=ON`
- `cmake --build build`
- `cd build && ctest`


------
https://chatgpt.com/codex/tasks/task_e_68bf1957af44832ca294ca487a46cc77